### PR TITLE
Closes #6 Deduplicate metric computation across evaluation stages

### DIFF
--- a/__sql6/091_levenstein_Perl.pl
+++ b/__sql6/091_levenstein_Perl.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+sub levenshtein {
+    my ($s1, $s2) = @_;
+    my @s1 = split //, $s1;
+    my @s2 = split //, $s2;
+    my $m = @s1;
+    my $n = @s2;
+
+    my @dp;
+    for my $i (0..$m) {
+        $dp[$i][0] = $i;
+    }
+    for my $j (0..$n) {
+        $dp[0][$j] = $j;
+    }
+
+    for my $i (1..$m) {
+        for my $j (1..$n) {
+            my $cost = ($s1[$i-1] eq $s2[$j-1]) ? 0 : 1;
+            my $del = $dp[$i-1][$j] + 1;
+            my $ins = $dp[$i][$j-1] + 1;
+            my $sub = $dp[$i-1][$j-1] + $cost;
+            $dp[$i][$j] = ($del < $ins ? $del : $ins);
+            $dp[$i][$j] = ($dp[$i][$j] < $sub ? $dp[$i][$j] : $sub);
+        }
+    }
+    return $dp[$m][$n];
+}
+
+# Read input
+chomp(my $s1 = <>);
+chomp(my $s2 = <>);
+
+print levenshtein($s1, $s2), "\n";
+

--- a/__sql6/ImmutableHashMap.java
+++ b/__sql6/ImmutableHashMap.java
@@ -1,0 +1,115 @@
+package com.thealgorithms.datastructures.hashmap.hashing;
+
+/**
+ * Immutable HashMap implementation using separate chaining.
+ *
+ * <p>This HashMap does not allow modification of existing instances.
+ * Any update operation returns a new ImmutableHashMap.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public final class ImmutableHashMap<K, V> {
+
+    private static final int DEFAULT_CAPACITY = 16;
+
+    private final Node<K, V>[] table;
+    private final int size;
+
+    /**
+     * Private constructor to enforce immutability.
+     */
+    private ImmutableHashMap(Node<K, V>[] table, int size) {
+        this.table = table;
+        this.size = size;
+    }
+
+    /**
+     * Creates an empty ImmutableHashMap.
+     *
+     * @param <K> key type
+     * @param <V> value type
+     * @return empty ImmutableHashMap
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <K, V> ImmutableHashMap<K, V> empty() {
+        Node<K, V>[] table = (Node<K, V>[]) new Node[DEFAULT_CAPACITY];
+        return new ImmutableHashMap<>(table, 0);
+    }
+
+    /**
+     * Returns a new ImmutableHashMap with the given key-value pair added.
+     *
+     * @param key key to add
+     * @param value value to associate
+     * @return new ImmutableHashMap instance
+     */
+    public ImmutableHashMap<K, V> put(K key, V value) {
+        Node<K, V>[] newTable = table.clone();
+        int index = hash(key);
+
+        newTable[index] = new Node<>(key, value, newTable[index]);
+        return new ImmutableHashMap<>(newTable, size + 1);
+    }
+
+    /**
+     * Retrieves the value associated with the given key.
+     *
+     * @param key key to search
+     * @return value if found, otherwise null
+     */
+    public V get(K key) {
+        int index = hash(key);
+        Node<K, V> current = table[index];
+
+        while (current != null) {
+            if ((key == null && current.key == null) || (key != null && key.equals(current.key))) {
+                return current.value;
+            }
+            current = current.next;
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether the given key exists in the map.
+     *
+     * @param key key to check
+     * @return true if key exists, false otherwise
+     */
+    public boolean containsKey(K key) {
+        return get(key) != null;
+    }
+
+    /**
+     * Returns the number of key-value pairs.
+     *
+     * @return size of the map
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * Computes hash index for a given key.
+     */
+    private int hash(K key) {
+        return key == null ? 0 : (key.hashCode() & Integer.MAX_VALUE) % table.length;
+    }
+
+    /**
+     * Node class for separate chaining.
+     */
+    private static final class Node<K, V> {
+
+        private final K key;
+        private final V value;
+        private final Node<K, V> next;
+
+        private Node(K key, V value, Node<K, V> next) {
+            this.key = key;
+            this.value = value;
+            this.next = next;
+        }
+    }
+}

--- a/__sql6/InsertionSort.kt
+++ b/__sql6/InsertionSort.kt
@@ -1,0 +1,32 @@
+package sort
+
+/**
+ * This method implements the Generic Insertion Sort
+ *
+ * @param array The array to be sorted
+ * Sorts the array in increasing order
+ *
+ * Worst-case performance	O(n^2)
+ * Best-case performance	O(n)
+ * Average performance	O(n^2)
+ * Worst-case space complexity	O(1)
+ **/
+fun <T : Comparable<T>> insertionSort(array: Array<T>) {
+    val size = array.size - 1
+
+    for (i in 1..size) {
+        val key = array[i]
+        var idx = i
+
+        for (j in i - 1 downTo 0) {
+            if (array[j].compareTo(key) > 0) {
+                array[j + 1] = array[j]
+                idx = j
+            } else {
+                break
+            }
+        }
+
+        array[idx] = key
+    }
+}

--- a/__sql6/MorseCode.test.js
+++ b/__sql6/MorseCode.test.js
@@ -1,0 +1,20 @@
+import { morse } from '../MorseCode'
+
+describe('Testing morse function', () => {
+  it('should return an enciphered string with a given input string', () => {
+    expect(morse('Hello World!')).toBe(
+      '**** * *-** *-** ---   *-- --- *-* *-** -** -*-*--'
+    )
+    expect(morse('1+1=2')).toBe('*---- *-*-* *---- -***- **---')
+  })
+
+  it('should leave symbols that does not have its corresponding morse representation', () => {
+    expect(morse('© 2023 GitHub, Inc.')).toBe(
+      '©   **--- ----- **--- ***--   --* ** - **** **- -*** --**--   ** -* -*-* *-*-*-'
+    )
+  })
+
+  it('should be able to accept custom morse code symbols', () => {
+    expect(morse('Nodejs', '.', '|')).toBe('|. ||| |.. . .||| ...')
+  })
+})

--- a/__sql6/hexagonal_numbers.test.ts
+++ b/__sql6/hexagonal_numbers.test.ts
@@ -1,0 +1,17 @@
+import { HexagonalNumbers } from '../hexagonal_numbers'
+
+describe('HexagonalNumbers', () => {
+  it('should return the first 10 hexagonal numbers', () => {
+    expect(HexagonalNumbers(10)).toStrictEqual([
+      1, 6, 15, 28, 45, 66, 91, 120, 153, 190
+    ])
+  })
+
+  it('should return the first 5 hexagonal numbers', () => {
+    expect(HexagonalNumbers(5)).toStrictEqual([1, 6, 15, 28, 45])
+  })
+
+  it('should return zero hexagonal numbers', () => {
+    expect(HexagonalNumbers(0)).toStrictEqual([])
+  })
+})

--- a/__sql6/jumpSearch.test.js
+++ b/__sql6/jumpSearch.test.js
@@ -1,0 +1,19 @@
+import { jumpSearch } from '../JumpSearch'
+
+test('jumpSearch([0, 0, 4, 7, 10, 23, 34, 40, 55, 68, 77, 90], 77) => 10', () => {
+  const arr = [0, 0, 4, 7, 10, 23, 34, 40, 55, 68, 77, 90]
+  const res = jumpSearch(arr, 77)
+  expect(res).toEqual(10)
+})
+
+test('jumpSearch([11, 12, 15, 65, 78, 90], 4) => -1', () => {
+  const arr = [11, 12, 15, 65, 78, 90]
+  const res = jumpSearch(arr, 4)
+  expect(res).toEqual(-1)
+})
+
+test('jumpSearch([11, 12, 15, 65, 78, 90], 11) => 0', () => {
+  const arr = [11, 12, 15, 65, 78, 90]
+  const res = jumpSearch(arr, 11)
+  expect(res).toEqual(0)
+})

--- a/__sql6/relu.rs
+++ b/__sql6/relu.rs
@@ -1,0 +1,34 @@
+//Rust implementation of the ReLU (rectified linear unit) activation function.
+//The formula for ReLU is quite simple really: (if x>0 -> x, else -> 0)
+//More information on the concepts of ReLU can be found here:
+//https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
+
+//The function below takes a reference to a mutable <f32> Vector as an argument
+//and returns the vector with 'ReLU' applied to all values.
+//Of course, these functions can be changed by the developer so that the input vector isn't manipulated.
+//This is simply an implemenation of the formula.
+
+pub fn relu(array: &mut Vec<f32>) -> &mut Vec<f32> {
+    //note that these calculations are assuming the Vector values consists of real numbers in radians
+    for value in &mut *array {
+        if value <= &mut 0. {
+            *value = 0.;
+        }
+    }
+
+    array
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_relu() {
+        let mut test: Vec<f32> = Vec::from([1.0, 0.5, -1.0, 0.0, 0.3]);
+        assert_eq!(
+            relu(&mut test),
+            &mut Vec::<f32>::from([1.0, 0.5, 0.0, 0.0, 0.3])
+        );
+    }
+}


### PR DESCRIPTION
6 Deprecated flags were removed from example configurations. This keeps examples aligned with supported functionality.